### PR TITLE
orbital core user registration

### DIFF
--- a/contracts/orbital-core/src/account_types.rs
+++ b/contracts/orbital-core/src/account_types.rs
@@ -45,7 +45,7 @@ impl UncheckedOrbitalDomainConfig {
                     StdError::generic_err("timeout must be non-zero")
                 );
 
-                Ok(OrbitalDomainConfig::ICA {
+                Ok(OrbitalDomainConfig::InterchainAccount {
                     connection_id,
                     channel_id,
                     timeout,

--- a/contracts/orbital-core/src/contract.rs
+++ b/contracts/orbital-core/src/contract.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;

--- a/contracts/orbital-core/src/contract.rs
+++ b/contracts/orbital-core/src/contract.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cw2::set_contract_version;
@@ -9,7 +11,7 @@ use crate::{
     account_types::AccountConfigType,
     error::ContractError,
     msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
-    state::ORBITAL_DOMAINS,
+    state::{UserConfig, ORBITAL_DOMAINS, USER_CONFIGS},
 };
 use cosmwasm_std::{
     to_json_binary, Addr, Binary, BlockInfo, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
@@ -46,7 +48,20 @@ pub fn execute(
             domain,
             account_type,
         } => admin_register_new_domain(deps, info, domain, account_type),
+        ExecuteMsg::RegisterUser {} => register_user(deps, env, info),
     }
+}
+
+fn register_user(deps: DepsMut, _env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+    // user can only register once
+    if USER_CONFIGS.has(deps.storage, info.sender.clone()) {
+        return Err(ContractError::UserAlreadyRegistered {});
+    }
+
+    // save an empty user config
+    USER_CONFIGS.save(deps.storage, info.sender, &UserConfig::default())?;
+
+    Ok(Response::new().add_attribute("method", "register_user"))
 }
 
 fn admin_update_ownership(
@@ -91,10 +106,16 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Ownership {} => to_json_binary(&get_ownership(deps.storage)?),
         QueryMsg::OrbitalDomain { domain } => query_orbital_domain(deps, domain),
+        QueryMsg::UserConfig { user } => query_user_config(deps, user),
     }
 }
 
 fn query_orbital_domain(deps: Deps, domain: String) -> StdResult<Binary> {
     let domain_config = ORBITAL_DOMAINS.load(deps.storage, domain)?;
     to_json_binary(&domain_config)
+}
+
+fn query_user_config(deps: Deps, user: String) -> StdResult<Binary> {
+    let user_config = USER_CONFIGS.load(deps.storage, Addr::unchecked(user))?;
+    to_json_binary(&user_config)
 }

--- a/contracts/orbital-core/src/contract.rs
+++ b/contracts/orbital-core/src/contract.rs
@@ -1,4 +1,3 @@
-
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cw2::set_contract_version;

--- a/contracts/orbital-core/src/error.rs
+++ b/contracts/orbital-core/src/error.rs
@@ -12,4 +12,7 @@ pub enum ContractError {
 
     #[error("Orbital domain already registered: {0}")]
     OrbitalDomainAlreadyExists(String),
+
+    #[error("User already registered")]
+    UserAlreadyRegistered {},
 }

--- a/contracts/orbital-core/src/msg.rs
+++ b/contracts/orbital-core/src/msg.rs
@@ -21,7 +21,7 @@ pub enum ExecuteMsg {
         // type of account to be used
         account_type: AccountConfigType,
     },
-    ///
+
     RegisterUser {},
 }
 

--- a/contracts/orbital-core/src/msg.rs
+++ b/contracts/orbital-core/src/msg.rs
@@ -1,7 +1,10 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
 
-use crate::{account_types::AccountConfigType, state::OrbitalDomainConfig};
+use crate::{
+    account_types::AccountConfigType,
+    state::{OrbitalDomainConfig, UserConfig},
+};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -11,12 +14,15 @@ pub struct InstantiateMsg {
 #[cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
+    /// admin-gated action to enable new orbital domains
     RegisterNewDomain {
         // string identifier for the domain
         domain: String,
         // type of account to be used
         account_type: AccountConfigType,
     },
+    ///
+    RegisterUser {},
 }
 
 #[cw_ownable_query]
@@ -25,4 +31,7 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(OrbitalDomainConfig)]
     OrbitalDomain { domain: String },
+
+    #[returns(UserConfig)]
+    UserConfig { user: String },
 }

--- a/contracts/orbital-core/src/state.rs
+++ b/contracts/orbital-core/src/state.rs
@@ -8,19 +8,13 @@ use cw_storage_plus::Map;
 pub const USER_CONFIGS: Map<Addr, UserConfig> = Map::new("user_configs");
 
 #[cw_serde]
+#[derive(Default)]
 pub struct UserConfig {
     // TODO: this may make more sense to have as a top level map
     // with composite keys of (user, domain) -> clearing_addr
     pub clearing_accounts: HashMap<String, String>,
 }
 
-impl Default for UserConfig {
-    fn default() -> Self {
-        UserConfig {
-            clearing_accounts: HashMap::new(),
-        }
-    }
-}
 
 /// map of registered remote domains and their configuration
 pub const ORBITAL_DOMAINS: Map<String, OrbitalDomainConfig> = Map::new("domains");

--- a/contracts/orbital-core/src/state.rs
+++ b/contracts/orbital-core/src/state.rs
@@ -21,14 +21,14 @@ pub struct UserConfig {
 /// remote domain configuration config which supports different types of account implementations.
 /// currently supported types:
 /// - Polytone: cw-based account implementation that operates via note contract on the origin chain
-/// - ICA: interchain account implementation based on ICS-27
+/// - InterchainAccount: interchain account implementation based on ICS-27
 #[cw_serde]
 pub enum OrbitalDomainConfig {
     Polytone {
         note: Addr,
         timeout: Uint64,
     },
-    ICA {
+    InterchainAccount {
         connection_id: String,
         channel_id: String,
         timeout: Uint64,

--- a/contracts/orbital-core/src/state.rs
+++ b/contracts/orbital-core/src/state.rs
@@ -1,6 +1,26 @@
+use std::collections::HashMap;
+
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Uint64};
 use cw_storage_plus::Map;
+
+/// map of users with their respective configurations
+pub const USER_CONFIGS: Map<Addr, UserConfig> = Map::new("user_configs");
+
+#[cw_serde]
+pub struct UserConfig {
+    // TODO: this may make more sense to have as a top level map
+    // with composite keys of (user, domain) -> clearing_addr
+    pub clearing_accounts: HashMap<String, String>,
+}
+
+impl Default for UserConfig {
+    fn default() -> Self {
+        UserConfig {
+            clearing_accounts: HashMap::new(),
+        }
+    }
+}
 
 /// map of registered remote domains and their configuration
 pub const ORBITAL_DOMAINS: Map<String, OrbitalDomainConfig> = Map::new("domains");
@@ -8,6 +28,7 @@ pub const ORBITAL_DOMAINS: Map<String, OrbitalDomainConfig> = Map::new("domains"
 /// remote domain configuration config which supports different types of account implementations.
 /// currently supported types:
 /// - Polytone: cw-based account implementation that operates via note contract on the origin chain
+/// - ICA: interchain account implementation based on ICS-27
 #[cw_serde]
 pub enum OrbitalDomainConfig {
     Polytone {

--- a/contracts/orbital-core/src/state.rs
+++ b/contracts/orbital-core/src/state.rs
@@ -7,6 +7,9 @@ use cw_storage_plus::Map;
 /// map of users with their respective configurations
 pub const USER_CONFIGS: Map<Addr, UserConfig> = Map::new("user_configs");
 
+/// map of registered remote domains and their configuration
+pub const ORBITAL_DOMAINS: Map<String, OrbitalDomainConfig> = Map::new("domains");
+
 #[cw_serde]
 #[derive(Default)]
 pub struct UserConfig {
@@ -14,10 +17,6 @@ pub struct UserConfig {
     // with composite keys of (user, domain) -> clearing_addr
     pub clearing_accounts: HashMap<String, String>,
 }
-
-
-/// map of registered remote domains and their configuration
-pub const ORBITAL_DOMAINS: Map<String, OrbitalDomainConfig> = Map::new("domains");
 
 /// remote domain configuration config which supports different types of account implementations.
 /// currently supported types:

--- a/contracts/orbital-core/src/tests/ctx.rs
+++ b/contracts/orbital-core/src/tests/ctx.rs
@@ -1,9 +1,11 @@
-use cosmwasm_std::{Addr, Empty};
-use cw_multi_test::{App, Contract, ContractWrapper, Executor};
+use cosmwasm_std::{Addr, Empty, StdResult, Uint64};
+use cw_multi_test::{error::AnyResult, App, AppResponse, Contract, ContractWrapper, Executor};
 
 use crate::{
+    account_types::AccountConfigType,
     contract::{execute, instantiate, query},
-    msg::InstantiateMsg,
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    state::OrbitalDomainConfig,
 };
 
 const OWNER: &str = "owner";
@@ -23,6 +25,32 @@ pub struct Suite {
 
 fn make_addr(app: &App, addr: &str) -> Addr {
     app.api().addr_make(addr)
+}
+
+impl Suite {
+    pub fn query_domain(&mut self, domain: &str) -> StdResult<OrbitalDomainConfig> {
+        self.app.wrap().query_wasm_smart(
+            self.orbital.clone(),
+            &QueryMsg::OrbitalDomain {
+                domain: domain.to_string(),
+            },
+        )
+    }
+    pub fn register_new_domain(
+        &mut self,
+        domain: &str,
+        account_type: AccountConfigType,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            self.owner.clone(),
+            self.orbital.clone(),
+            &ExecuteMsg::RegisterNewDomain {
+                domain: domain.to_string(),
+                account_type,
+            },
+            &[],
+        )
+    }
 }
 
 impl Default for Suite {

--- a/contracts/orbital-core/src/tests/ctx.rs
+++ b/contracts/orbital-core/src/tests/ctx.rs
@@ -1,11 +1,11 @@
-use cosmwasm_std::{Addr, Empty, StdResult, Uint64};
+use cosmwasm_std::{Addr, Empty, StdResult};
 use cw_multi_test::{error::AnyResult, App, AppResponse, Contract, ContractWrapper, Executor};
 
 use crate::{
     account_types::AccountConfigType,
     contract::{execute, instantiate, query},
     msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
-    state::OrbitalDomainConfig,
+    state::{OrbitalDomainConfig, UserConfig},
 };
 
 const OWNER: &str = "owner";
@@ -28,11 +28,27 @@ fn make_addr(app: &App, addr: &str) -> Addr {
 }
 
 impl Suite {
+    pub fn register_user(&mut self, user_addr: &str) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            make_addr(&self.app, user_addr),
+            self.orbital.clone(),
+            &ExecuteMsg::RegisterUser {},
+            &[],
+        )
+    }
     pub fn query_domain(&mut self, domain: &str) -> StdResult<OrbitalDomainConfig> {
         self.app.wrap().query_wasm_smart(
             self.orbital.clone(),
             &QueryMsg::OrbitalDomain {
                 domain: domain.to_string(),
+            },
+        )
+    }
+    pub fn query_user(&mut self, user: &str) -> StdResult<UserConfig> {
+        self.app.wrap().query_wasm_smart(
+            self.orbital.clone(),
+            &QueryMsg::UserConfig {
+                user: make_addr(&self.app, user).to_string(),
             },
         )
     }

--- a/contracts/orbital-core/src/tests/unit_tests.rs
+++ b/contracts/orbital-core/src/tests/unit_tests.rs
@@ -162,6 +162,21 @@ fn test_register_orbital_domain_happy() {
 }
 
 #[test]
-fn test_register_user() {
-    unimplemented!()
+#[should_panic(expected = "User already registered")]
+fn test_register_user_duplicate() {
+    let mut suite = Suite::default();
+
+    suite.register_user("user").unwrap();
+    suite.register_user("user").unwrap();
+}
+
+#[test]
+fn test_register_user_happy() {
+    let mut suite = Suite::default();
+
+    suite.register_user("user").unwrap();
+
+    let user_config = suite.query_user("user").unwrap();
+
+    assert!(user_config.clearing_accounts.is_empty());
 }

--- a/contracts/orbital-core/src/tests/unit_tests.rs
+++ b/contracts/orbital-core/src/tests/unit_tests.rs
@@ -28,18 +28,12 @@ fn test_register_orbital_domain_validates_addr() {
     let mut suite = Suite::default();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner,
-            suite.orbital,
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "domain".to_string(),
-                account_type: AccountConfigType::Polytone {
-                    note: "invalid_note".to_string(),
-                    timeout: Uint64::one(),
-                },
+        .register_new_domain(
+            "domain",
+            AccountConfigType::Polytone {
+                note: "invalid_note".to_string(),
+                timeout: Uint64::one(),
             },
-            &[],
         )
         .unwrap();
 }
@@ -50,34 +44,22 @@ fn test_register_duplicate_orbital_domain() {
     let mut suite = Suite::default();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner.clone(),
-            suite.orbital.clone(),
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "".to_string(),
-                account_type: AccountConfigType::Polytone {
-                    note: suite.note.to_string(),
-                    timeout: Uint64::one(),
-                },
+        .register_new_domain(
+            "",
+            AccountConfigType::Polytone {
+                note: suite.note.to_string(),
+                timeout: Uint64::one(),
             },
-            &[],
         )
         .unwrap();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner,
-            suite.orbital,
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "".to_string(),
-                account_type: AccountConfigType::Polytone {
-                    note: suite.note.to_string(),
-                    timeout: Uint64::one(),
-                },
+        .register_new_domain(
+            "",
+            AccountConfigType::Polytone {
+                note: suite.note.to_string(),
+                timeout: Uint64::one(),
             },
-            &[],
         )
         .unwrap();
 }
@@ -110,19 +92,13 @@ fn test_register_orbital_ica_domain_validates_timeout() {
     let mut suite = Suite::default();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner,
-            suite.orbital,
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "domain".to_string(),
-                account_type: AccountConfigType::ICA {
-                    connection_id: "connection-id".to_string(),
-                    channel_id: "channel-id".to_string(),
-                    timeout: Uint64::zero(),
-                },
+        .register_new_domain(
+            "domain",
+            AccountConfigType::ICA {
+                connection_id: "connection-id".to_string(),
+                channel_id: "channel-id".to_string(),
+                timeout: Uint64::zero(),
             },
-            &[],
         )
         .unwrap();
 }
@@ -133,18 +109,12 @@ fn test_register_orbital_polytone_domain_validates_timeout() {
     let mut suite = Suite::default();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner,
-            suite.orbital,
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "domain".to_string(),
-                account_type: AccountConfigType::Polytone {
-                    note: suite.note.to_string(),
-                    timeout: Uint64::zero(),
-                },
+        .register_new_domain(
+            "domain",
+            AccountConfigType::Polytone {
+                note: suite.note.to_string(),
+                timeout: Uint64::zero(),
             },
-            &[],
         )
         .unwrap();
 }
@@ -154,58 +124,29 @@ fn test_register_orbital_domain_happy() {
     let mut suite = Suite::default();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner.clone(),
-            suite.orbital.clone(),
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "domain_polytone".to_string(),
-                account_type: AccountConfigType::Polytone {
-                    note: suite.note.to_string(),
-                    timeout: Uint64::one(),
-                },
+        .register_new_domain(
+            "domain_polytone",
+            AccountConfigType::Polytone {
+                note: suite.note.to_string(),
+                timeout: Uint64::one(),
             },
-            &[],
         )
         .unwrap();
 
     suite
-        .app
-        .execute_contract(
-            suite.owner,
-            suite.orbital.clone(),
-            &ExecuteMsg::RegisterNewDomain {
-                domain: "domain_ica".to_string(),
-                account_type: AccountConfigType::ICA {
-                    connection_id: "connection-id".to_string(),
-                    channel_id: "channel-id".to_string(),
-                    timeout: Uint64::one(),
-                },
+        .register_new_domain(
+            "domain_ica",
+            AccountConfigType::ICA {
+                connection_id: "connection-id".to_string(),
+                channel_id: "channel-id".to_string(),
+                timeout: Uint64::one(),
             },
-            &[],
         )
         .unwrap();
 
-    let polytone_domain: OrbitalDomainConfig = suite
-        .app
-        .wrap()
-        .query_wasm_smart(
-            suite.orbital.clone(),
-            &QueryMsg::OrbitalDomain {
-                domain: "domain_polytone".to_string(),
-            },
-        )
-        .unwrap();
-    let ica_domain: OrbitalDomainConfig = suite
-        .app
-        .wrap()
-        .query_wasm_smart(
-            suite.orbital.clone(),
-            &QueryMsg::OrbitalDomain {
-                domain: "domain_ica".to_string(),
-            },
-        )
-        .unwrap();
+    let polytone_domain = suite.query_domain("domain_polytone").unwrap();
+
+    let ica_domain = suite.query_domain("domain_ica").unwrap();
 
     assert!(matches!(
         polytone_domain,
@@ -218,4 +159,9 @@ fn test_register_orbital_domain_happy() {
         OrbitalDomainConfig::ICA { connection_id, channel_id, timeout }
         if connection_id == "connection-id" && channel_id == "channel-id" && timeout == Uint64::one()
     ));
+}
+
+#[test]
+fn test_register_user() {
+    unimplemented!()
 }

--- a/contracts/orbital-core/src/tests/unit_tests.rs
+++ b/contracts/orbital-core/src/tests/unit_tests.rs
@@ -156,7 +156,7 @@ fn test_register_orbital_domain_happy() {
 
     assert!(
         ica_domain
-            == OrbitalDomainConfig::ICA {
+            == OrbitalDomainConfig::InterchainAccount {
                 connection_id: "connection-id".to_string(),
                 channel_id: "channel-id".to_string(),
                 timeout: Uint64::one()


### PR DESCRIPTION
closes #7 
blocked by #13 .

enables users to register with the system by creating an empty `UserConfig`.
this is a prerequisite for users registering to operate on any domains (#3).

also streamlines the test context a little by adding some helper functions.